### PR TITLE
feat: support multiple auth methods with default and fallback switching

### DIFF
--- a/conf/module.xml
+++ b/conf/module.xml
@@ -21,6 +21,7 @@
 		<action name="procGoogleotpUserConfig" type="controller"/>
 		<action name="procGoogleotpInputotp" type="controller"/>
 		<action name="procGoogleotpResendauthmessage" type="controller" />
+		<action name="procGoogleotpSwitchAuthMethod" type="controller" />
 		<action name="procGoogleotpDeleteTrustedDevice" type="controller" />
 		<action name="procGoogleotpDeleteAllTrustedDevices" type="controller" />
 

--- a/googleotp.class.php
+++ b/googleotp.class.php
@@ -305,6 +305,8 @@ class googleotp extends ModuleObject
 		$oDB = DB::getInstance();
 		if (!$oDB->isColumnExists('googleotp_memberconfig', 'issue_type')) return true;
 		if (!$oDB->isColumnExists('googleotp_authlog', 'issue_type')) return true;
+		if (!$oDB->isColumnExists('googleotp_memberconfig', 'default_issue_type')) return true;
+		if ($oDB->getColumnInfo('googleotp_memberconfig', 'issue_type')->size < 50) return true;
 
 		return false;
 	}
@@ -323,11 +325,19 @@ class googleotp extends ModuleObject
 		$oDB = DB::getInstance();
 		if (!$oDB->isColumnExists('googleotp_memberconfig', 'issue_type'))
 		{
-			$oDB->addColumn('googleotp_memberconfig', 'issue_type', 'varchar', 10, 'none', true);
+			$oDB->addColumn('googleotp_memberconfig', 'issue_type', 'varchar', 50, 'none', true);
 		}
 		if (!$oDB->isColumnExists('googleotp_authlog', 'issue_type'))
 		{
 			$oDB->addColumn('googleotp_authlog', 'issue_type', 'varchar', 10, 'none', true);
+		}
+		if (!$oDB->isColumnExists('googleotp_memberconfig', 'default_issue_type'))
+		{
+			$oDB->addColumn('googleotp_memberconfig', 'default_issue_type', 'varchar', 10, 'none', true);
+		}
+		if ($oDB->getColumnInfo('googleotp_memberconfig', 'issue_type')->size < 50)
+		{
+			$oDB->modifyColumn('googleotp_memberconfig', 'issue_type', 'varchar', 50, null, true);
 		}
 
 		return $this->createObject(0, 'success_updated');

--- a/queries/updateGoogleotpuserconfigbySrl.xml
+++ b/queries/updateGoogleotpuserconfigbySrl.xml
@@ -5,6 +5,7 @@
     <columns>
         <column name="use" var="use" notnull="notnull" />
         <column name="issue_type" var="issue_type" notnull="notnull" />
+        <column name="default_issue_type" var="default_issue_type" />
     </columns>
     <conditions>
         <condition operation="equal" column="srl" var="srl" filter="number" notnull="notnull" />

--- a/schemas/googleotp_memberconfig.xml
+++ b/schemas/googleotp_memberconfig.xml
@@ -3,5 +3,6 @@
     <column name="srl" type="number" notnull="notnull" />
     <column name="otp_id" type="varchar" size="16" notnull="notnull" index="idx_otp_id" />
     <column name="use" type="varchar" size="5" notnull="notnull" index="idx_use" />
-    <column name="issue_type" type="varchar" size="10" notnull="notnull" default="none" />
+    <column name="issue_type" type="varchar" size="50" notnull="notnull" default="none" />
+    <column name="default_issue_type" type="varchar" size="10" notnull="notnull" default="none" />
 </table>

--- a/skins/default/inputotp.html
+++ b/skins/default/inputotp.html
@@ -5,24 +5,24 @@
         <p>{$XE_VALIDATOR_MESSAGE}</p>
     </div>
 
-    <!--@if($user_config->issue_type == 'email')-->
+    <!--@if($active_issue_type == 'email')-->
     <div class="message info">
         <p>{substr($logged_info->email_id,0,5)}*******@{$logged_info->email_host} 으로 인증 메일이 발송되었습니다</p>
         <p>메일함을 확인해주세요</p>
     </div>
-    <!--@elseif($user_config->issue_type == 'sms')-->
+    <!--@elseif($active_issue_type == 'sms')-->
     <div class="message info">
         <p><!--@for($i=0;$i<strlen($logged_info->phone_number)-4;$i++)-->*<!--@end-->{substr($logged_info->phone_number,-4)}로 인증 문자가 발송되었습니다</p>
         <p>문자 메세지를 확인해주세요</p>
     </div>
-    <!--@elseif($user_config->issue_type == 'passkey')-->
+    <!--@elseif($active_issue_type == 'passkey')-->
     <div class="message info">
         <p>패스키 인증을 진행해주세요.</p>
         <p>아래 버튼을 눌러 지문, 얼굴 인식 또는 보안 키로 인증해주세요.</p>
     </div>
     <!--@endif-->
 
-    <!--@if($user_config->issue_type == 'passkey')-->
+    <!--@if($active_issue_type == 'passkey')-->
     <div id="passkey_auth_section">
         <section class="section">
             <h1>로그인 2차 인증 (패스키)</h1>
@@ -46,6 +46,32 @@
             </div>
             <!--@endif-->
         </section>
+        <!--@if($alternative_types && count($alternative_types) > 0)-->
+        <section class="section">
+            <h1>다른 인증 방식 사용</h1>
+            <div class="control-group">
+                <div class="controls">
+                    <p class="help-block">선택한 인증 방식을 사용할 수 없는 경우, 다른 방식으로 전환할 수 있습니다.</p>
+                    <!--@foreach($alternative_types as $alt_type)-->
+                    <form action="./" method="post" style="display:inline; margin-right:5px;">
+                        <input type="hidden" name="module" value="googleotp" />
+                        <input type="hidden" name="act" value="procGoogleotpSwitchAuthMethod" />
+                        <input type="hidden" name="switch_to" value="{$alt_type}" />
+                        <!--@if($alt_type == 'otp')-->
+                        <button type="submit" class="btn">Google OTP로 전환</button>
+                        <!--@elseif($alt_type == 'email')-->
+                        <button type="submit" class="btn">이메일 인증으로 전환</button>
+                        <!--@elseif($alt_type == 'sms')-->
+                        <button type="submit" class="btn">SMS 인증으로 전환</button>
+                        <!--@elseif($alt_type == 'passkey')-->
+                        <button type="submit" class="btn">패스키로 전환</button>
+                        <!--@endif-->
+                    </form>
+                    <!--@end-->
+                </div>
+            </div>
+        </section>
+        <!--@endif-->
         <div class="clearfix btnArea">
             <div class="pull-right">
                 <button class="btn btn-secondary" type="button" onclick="location.href='{getUrl('','act','dispMemberLogout')}'">로그아웃</button>
@@ -65,19 +91,19 @@
                 <label class="control-label">인증 번호 입력</label>
                 <div class="controls">
                     <input type="text" name="otpinput" required />
-                    <!--@if($user_config->issue_type == 'otp')-->
+                    <!--@if($active_issue_type == 'otp')-->
                     <p class="help-block">Google OTP 앱에 뜬 번호를 입력해주세요.</p>
-                    <!--@elseif($user_config->issue_type == 'email')-->
+                    <!--@elseif($active_issue_type == 'email')-->
                     <p class="help-block">이메일로 발송된 인증 번호를 입력해주세요.</p>
-                    <!--@elseif($user_config->issue_type == 'sms')-->
+                    <!--@elseif($active_issue_type == 'sms')-->
                     <p class="help-block">문자로 발송된 인증 번호를 입력해주세요.</p>
                     <!--@endif-->
                 </div>
             </div>
-            <div class="control-group" cond="in_array($user_config->issue_type, ['email','sms'])">
-                <label class="control-label">인증 <!--@if($user_config->issue_type == 'email')-->메일<!--@elseif($user_config->issue_type == 'sms')-->문자<!--@endif--> 재전송</label>
+            <div class="control-group" cond="in_array($active_issue_type, ['email','sms'])">
+                <label class="control-label">인증 <!--@if($active_issue_type == 'email')-->메일<!--@elseif($active_issue_type == 'sms')-->문자<!--@endif--> 재전송</label>
                 <div class="controls">
-                    <input type="button" id="reauth_send" class="btn" onclick="return false;" value="인증 <!--@if($user_config->issue_type == 'email')-->메일<!--@elseif($user_config->issue_type == 'sms')-->문자<!--@endif--> 재전송 (01:30)">
+                    <input type="button" id="reauth_send" class="btn" onclick="return false;" value="인증 <!--@if($active_issue_type == 'email')-->메일<!--@elseif($active_issue_type == 'sms')-->문자<!--@endif--> 재전송 (01:30)">
                 </div>
             </div>
             <!--@if($captcha)-->
@@ -107,11 +133,37 @@
             </div>
         </div>
     </form>
+    <!--@if($alternative_types && count($alternative_types) > 0)-->
+    <section class="section">
+        <h1>다른 인증 방식 사용</h1>
+        <div class="control-group">
+            <div class="controls">
+                <p class="help-block">선택한 인증 방식을 사용할 수 없는 경우, 다른 방식으로 전환할 수 있습니다.</p>
+                <!--@foreach($alternative_types as $alt_type)-->
+                <form action="./" method="post" style="display:inline; margin-right:5px;">
+                    <input type="hidden" name="module" value="googleotp" />
+                    <input type="hidden" name="act" value="procGoogleotpSwitchAuthMethod" />
+                    <input type="hidden" name="switch_to" value="{$alt_type}" />
+                    <!--@if($alt_type == 'otp')-->
+                    <button type="submit" class="btn">Google OTP로 전환</button>
+                    <!--@elseif($alt_type == 'email')-->
+                    <button type="submit" class="btn">이메일 인증으로 전환</button>
+                    <!--@elseif($alt_type == 'sms')-->
+                    <button type="submit" class="btn">SMS 인증으로 전환</button>
+                    <!--@elseif($alt_type == 'passkey')-->
+                    <button type="submit" class="btn">패스키로 전환</button>
+                    <!--@endif-->
+                </form>
+                <!--@end-->
+            </div>
+        </div>
+    </section>
+    <!--@endif-->
     <!--@endif-->
 </div>
 <load target="../../vendor/davidearl/webauthn/src/webauthnauthenticate.js" />
 <script>
-    <!--@if($user_config->issue_type != 'passkey')-->
+    <!--@if($active_issue_type != 'passkey')-->
     var timerId;
     var resend_time = 90;
     jQuery(document).ready(function(){
@@ -123,11 +175,11 @@
         if(resend_time <= 0)
         {
             clearInterval(timerId);
-            jQuery('#reauth_send').attr('onclick','return reSendAuth();').val('인증 <!--@if($user_config->issue_type == "email")-->메일<!--@elseif($user_config->issue_type == "sms")-->문자<!--@endif--> 재전송');
+            jQuery('#reauth_send').attr('onclick','return reSendAuth();').val('인증 <!--@if($active_issue_type == "email")-->메일<!--@elseif($active_issue_type == "sms")-->문자<!--@endif--> 재전송');
         }
         else
         {
-            jQuery('#reauth_send').attr('onclick','return false;').val('인증 <!--@if($user_config->issue_type == "email")-->메일<!--@elseif($user_config->issue_type == "sms")-->문자<!--@endif--> 재전송 ('+new Date(resend_time * 1000).toISOString().substr(14, 5)+')');
+            jQuery('#reauth_send').attr('onclick','return false;').val('인증 <!--@if($active_issue_type == "email")-->메일<!--@elseif($active_issue_type == "sms")-->문자<!--@endif--> 재전송 ('+new Date(resend_time * 1000).toISOString().substr(14, 5)+')');
         }
     }
     function reSendAuth()
@@ -139,7 +191,7 @@
             }
             else
             {
-                alert('인증 <!--@if($user_config->issue_type == "email")-->메일이<!--@elseif($user_config->issue_type == "sms")-->문자가<!--@endif--> 재발송되었습니다');
+                alert('인증 <!--@if($active_issue_type == "email")-->메일이<!--@elseif($active_issue_type == "sms")-->문자가<!--@endif--> 재발송되었습니다');
             }
         });
 
@@ -147,7 +199,7 @@
     }
     <!--@endif-->
 
-    <!--@if($user_config->issue_type == 'passkey')-->
+    <!--@if($active_issue_type == 'passkey')-->
     function authenticatePasskey(){
         if(!window.PublicKeyCredential){
             document.getElementById('passkey_auth_status').textContent = '이 브라우저는 패스키를 지원하지 않습니다.';

--- a/skins/default/userconfig.html
+++ b/skins/default/userconfig.html
@@ -32,46 +32,74 @@
             <div id="tfa_enabled" style="display:none"|cond="$user_config->use != 'Y' && !$force_use_otp">
                 <hr><br>
                 <div class="control-group">
-                    <label class="control-label">2차 인증 방식</label>
+                    <label class="control-label">2차 인증 방식 (복수 선택 가능)</label>
                     <div class="controls">
                         <!--@if(in_array('otp', $googleotp_config->allow_issue_type))-->
                         <label class="inline">
-                            <input type="radio" name="issue_type" id="auth_otp" value="otp" checked="checked"|cond="$user_config->issue_type == 'otp'" /> Google OTP
+                            <input type="checkbox" name="issue_type[]" id="auth_otp" value="otp" checked="checked"|cond="in_array('otp', explode(',', $user_config->issue_type))" /> Google OTP
                         </label>
                         <!--@endif-->
 
                         <!--@if(in_array('email', $googleotp_config->allow_issue_type))-->
                         <label class="inline">
-                            <input type="radio" name="issue_type" id="auth_email" value="email" checked="checked"|cond="$user_config->issue_type == 'email'" /> 이메일 인증
+                            <input type="checkbox" name="issue_type[]" id="auth_email" value="email" checked="checked"|cond="in_array('email', explode(',', $user_config->issue_type))" /> 이메일 인증
                         </label>
                         <!--@endif-->
 
                         <!--@if(in_array('sms', $googleotp_config->allow_issue_type))-->
                         <label class="inline">
-                            <input type="radio" name="issue_type" id="auth_sms" value="sms" checked="checked"|cond="$user_config->issue_type == 'sms'" /> SMS 인증
+                            <input type="checkbox" name="issue_type[]" id="auth_sms" value="sms" checked="checked"|cond="in_array('sms', explode(',', $user_config->issue_type))" /> SMS 인증
                         </label>
                         <!--@endif-->
 
                         <!--@if(in_array('passkey', $googleotp_config->allow_issue_type))-->
                         <label class="inline">
-                            <input type="radio" name="issue_type" id="auth_passkey" value="passkey" checked="checked"|cond="$user_config->issue_type == 'passkey'" /> 패스키 (Passkey)
+                            <input type="checkbox" name="issue_type[]" id="auth_passkey" value="passkey" checked="checked"|cond="in_array('passkey', explode(',', $user_config->issue_type))" /> 패스키 (Passkey)
                         </label>
                         <!--@endif-->
-                        <p class="help-block">인증 방식을 설정해주세요.</p>
-                        <p id="google_otp_help-block" style="display:none"|cond="$user_config->issue_type != 'otp'">주의 : 하단의 QR코드를 휴대폰에서 인식하여 Google OTP에 사이트를 추가해주세요.</p>
-                        <p id="email_auth_help-block" style="display:none"|cond="$user_config->issue_type != 'email'">주의 : 다음 로그인부터 해당 이메일({$user_mail})로 인증 메일이 발송됩니다.</p>
-                        <p id="sms_auth_help-block" style="display:none"|cond="$user_config->issue_type != 'sms'">주의 : 다음 로그인부터 해당 전화번호({$user_phone})로 인증 메세지가 발송됩니다.</p>
-                        <p id="passkey_auth_help-block" style="display:none"|cond="$user_config->issue_type != 'passkey'">패스키를 등록하면 지문, 얼굴 인식, 보안 키 등으로 2차 인증을 할 수 있습니다.</p>
+                        <p class="help-block">사용할 인증 방식을 선택해주세요. 여러 개를 선택하면 로그인 시 다른 방식으로 전환할 수 있습니다.</p>
                     </div>
                 </div>
-                <div class="control-group" id="google_otp_qr" style="display:none"|cond="$user_config->issue_type != 'otp'">
+                <div class="control-group" id="default_issue_type_group">
+                    <label class="control-label">기본 인증 방식</label>
+                    <div class="controls">
+                        <select name="default_issue_type" id="default_issue_type">
+                            <!--@if(in_array('otp', $googleotp_config->allow_issue_type))-->
+                            <option value="otp" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'otp'">Google OTP</option>
+                            <!--@endif-->
+                            <!--@if(in_array('email', $googleotp_config->allow_issue_type))-->
+                            <option value="email" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'email'">이메일 인증</option>
+                            <!--@endif-->
+                            <!--@if(in_array('sms', $googleotp_config->allow_issue_type))-->
+                            <option value="sms" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'sms'">SMS 인증</option>
+                            <!--@endif-->
+                            <!--@if(in_array('passkey', $googleotp_config->allow_issue_type))-->
+                            <option value="passkey" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'passkey'">패스키 (Passkey)</option>
+                            <!--@endif-->
+                        </select>
+                        <p class="help-block">로그인 시 기본으로 사용할 인증 방식을 선택해주세요.</p>
+                    </div>
+                </div>
+                <div id="google_otp_help-block" style="display:none"|cond="!in_array('otp', explode(',', $user_config->issue_type))">
+                    <p>주의 : 하단의 QR코드를 휴대폰에서 인식하여 Google OTP에 사이트를 추가해주세요.</p>
+                </div>
+                <div id="email_auth_help-block" style="display:none"|cond="!in_array('email', explode(',', $user_config->issue_type))">
+                    <p>주의 : 다음 로그인부터 해당 이메일({$user_mail})로 인증 메일이 발송됩니다.</p>
+                </div>
+                <div id="sms_auth_help-block" style="display:none"|cond="!in_array('sms', explode(',', $user_config->issue_type))">
+                    <p>주의 : 다음 로그인부터 해당 전화번호({$user_phone})로 인증 메세지가 발송됩니다.</p>
+                </div>
+                <div id="passkey_auth_help-block" style="display:none"|cond="!in_array('passkey', explode(',', $user_config->issue_type))">
+                    <p>패스키를 등록하면 지문, 얼굴 인식, 보안 키 등으로 2차 인증을 할 수 있습니다.</p>
+                </div>
+                <div class="control-group" id="google_otp_qr" style="display:none"|cond="!in_array('otp', explode(',', $user_config->issue_type))">
                     <label class="control-label">Google OTP QR코드</label>
                     <div class="controls">
                         <img src="{$user_config->qrcode}" />
                         <p class="help-block">Google OTP에 등록할 때 사용할 QR코드입니다 외부로 유출되지 않도록 아이디 및 절대 이 QR코드를 저장하지 마세요.</p>
                     </div>
                 </div>
-                <div class="control-group" id="google_otp_input" style="display:none"|cond="$user_config->issue_type != 'otp'">
+                <div class="control-group" id="google_otp_input" style="display:none"|cond="!in_array('otp', explode(',', $user_config->issue_type))">
                     <label class="control-label">확인용 인증코드</label>
                     <div class="controls">
                         <input type="number" name="test_auth_key" value="" />
@@ -138,37 +166,59 @@ $('#no_use_tfa').click(function(){
     $('#tfa_enabled').hide();
 });
 
-$('#auth_otp').click(function(){
-    $('#google_otp_qr').show();
-    $('#google_otp_input').show();
-    $('#google_otp_help-block').show();
-    $('#email_auth_help-block').hide();
-    $('#sms_auth_help-block').hide();
-    $('#passkey_auth_help-block').hide();
-});
-$('#auth_email').click(function(){
-    $('#google_otp_qr').hide();
-    $('#google_otp_input').hide();
-    $('#google_otp_help-block').hide();
-    $('#email_auth_help-block').show();
-    $('#sms_auth_help-block').hide();
-    $('#passkey_auth_help-block').hide();
-});
-$('#auth_sms').click(function(){
-    $('#google_otp_qr').hide();
-    $('#google_otp_input').hide();
-    $('#google_otp_help-block').hide();
-    $('#email_auth_help-block').hide();
-    $('#sms_auth_help-block').show();
-    $('#passkey_auth_help-block').hide();
-});
-$('#auth_passkey').click(function(){
-    $('#google_otp_qr').hide();
-    $('#google_otp_input').hide();
-    $('#google_otp_help-block').hide();
-    $('#email_auth_help-block').hide();
-    $('#sms_auth_help-block').hide();
-    $('#passkey_auth_help-block').show();
+function updateAuthHelpBlocks() {
+    var otpChecked = $('#auth_otp').is(':checked');
+    var emailChecked = $('#auth_email').is(':checked');
+    var smsChecked = $('#auth_sms').is(':checked');
+    var passkeyChecked = $('#auth_passkey').is(':checked');
+
+    $('#google_otp_help-block').toggle(otpChecked);
+    $('#google_otp_qr').toggle(otpChecked);
+    $('#google_otp_input').toggle(otpChecked);
+    $('#email_auth_help-block').toggle(emailChecked);
+    $('#sms_auth_help-block').toggle(smsChecked);
+    $('#passkey_auth_help-block').toggle(passkeyChecked);
+
+    updateDefaultIssueType();
+}
+
+function updateDefaultIssueType() {
+    var checkedTypes = [];
+    $('input[name="issue_type[]"]:checked').each(function(){
+        checkedTypes.push($(this).val());
+    });
+
+    $('#default_issue_type option').each(function(){
+        var optVal = $(this).val();
+        if(checkedTypes.indexOf(optVal) >= 0) {
+            $(this).prop('disabled', false).show();
+        } else {
+            $(this).prop('disabled', true).hide();
+        }
+    });
+
+    // 현재 선택된 기본 방식이 비활성화된 경우 첫 번째 활성화된 방식으로 변경
+    var currentDefault = $('#default_issue_type').val();
+    if(checkedTypes.indexOf(currentDefault) < 0 && checkedTypes.length > 0) {
+        $('#default_issue_type').val(checkedTypes[0]);
+    }
+
+    // 선택된 인증 방식이 없으면 기본 방식 선택 숨기기
+    if(checkedTypes.length <= 1) {
+        $('#default_issue_type_group').hide();
+    } else {
+        $('#default_issue_type_group').show();
+    }
+}
+
+$('#auth_otp').change(updateAuthHelpBlocks);
+$('#auth_email').change(updateAuthHelpBlocks);
+$('#auth_sms').change(updateAuthHelpBlocks);
+$('#auth_passkey').change(updateAuthHelpBlocks);
+
+// 초기 상태 설정
+$(document).ready(function(){
+    updateAuthHelpBlocks();
 });
 
 function registerPasskey(){

--- a/tpl/memberlist.html
+++ b/tpl/memberlist.html
@@ -21,7 +21,19 @@
 				<td>{$no}</td>
 				<td><a class="member_{$val->member_info->member_srl}" href="javascript:void(0);">{$val->member_info->nick_name}</a></td>
 				<td><!--@if($val->use == 'Y')--> 사용<!--@else-->사용 안 함<!--@end--></td>
-				<td><!--@if($val->issue_type == 'otp')-->Google OTP<!--@elseif($val->issue_type == 'email')-->이메일<!--@elseif($val->issue_type == 'sms')-->문자<!--@elseif($val->issue_type == 'passkey')-->패스키<!--@endif--></td>
+				<td>
+				{@$_types = explode(',', $val->issue_type)}
+				{@$_type_names = []}
+				<!--@foreach($_types as $_t)-->
+				{@
+					if($_t == 'otp') $_type_names[] = 'Google OTP';
+					elseif($_t == 'email') $_type_names[] = '이메일';
+					elseif($_t == 'sms') $_type_names[] = '문자';
+					elseif($_t == 'passkey') $_type_names[] = '패스키';
+				}
+				<!--@end-->
+				{implode(', ', $_type_names)}
+			</td>
 				<td><a href="{getUrl('', 'module', 'admin', 'act', 'dispGoogleotpAdminMemberSetup', 'srl', $val->srl, 'nick_name', $val->member_info->nick_name)}">수정</a></td>
 			</tr>
 			<!--@end-->

--- a/tpl/membersetup.html
+++ b/tpl/membersetup.html
@@ -27,22 +27,36 @@
 			</div>
 		</div>
 		<div class="x_control-group">
-			<label class="x_control-label" for="issue_type">인증 수단</label>
+			<label class="x_control-label">인증 수단 (복수 선택 가능)</label>
 			<div class="x_controls">
-				<select name="issue_type" id="issue_type">
-					<option value="otp" selected="selected"|cond="$user_config->issue_type == 'otp'" disabled="disabled"|cond="!in_array('otp', $googleotp_config->allow_issue_type)">
-						Google OTP <!--@if(!in_array('otp', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
-					</option>
-					<option value="email" selected="selected"|cond="$user_config->issue_type == 'email'" disabled="disabled"|cond="!in_array('email', $googleotp_config->allow_issue_type)">
-						이메일 <!--@if(!in_array('email', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
-					</option>
-					<option value="sms" selected="selected"|cond="$user_config->issue_type == 'sms'"  disabled="disabled"|cond="!in_array('sms', $googleotp_config->allow_issue_type)">
-						문자 (SMS) <!--@if(!in_array('sms', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
-					</option>
-					<option value="passkey" selected="selected"|cond="$user_config->issue_type == 'passkey'" disabled="disabled"|cond="!in_array('passkey', $googleotp_config->allow_issue_type)">
-						패스키 (Passkey) <!--@if(!in_array('passkey', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
-					</option>
+				<label class="inline">
+					<input type="checkbox" name="issue_type[]" value="otp" checked="checked"|cond="in_array('otp', explode(',', $user_config->issue_type))" disabled="disabled"|cond="!in_array('otp', $googleotp_config->allow_issue_type)" />
+					Google OTP <!--@if(!in_array('otp', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
+				</label>
+				<label class="inline">
+					<input type="checkbox" name="issue_type[]" value="email" checked="checked"|cond="in_array('email', explode(',', $user_config->issue_type))" disabled="disabled"|cond="!in_array('email', $googleotp_config->allow_issue_type)" />
+					이메일 <!--@if(!in_array('email', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
+				</label>
+				<label class="inline">
+					<input type="checkbox" name="issue_type[]" value="sms" checked="checked"|cond="in_array('sms', explode(',', $user_config->issue_type))" disabled="disabled"|cond="!in_array('sms', $googleotp_config->allow_issue_type)" />
+					문자 (SMS) <!--@if(!in_array('sms', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
+				</label>
+				<label class="inline">
+					<input type="checkbox" name="issue_type[]" value="passkey" checked="checked"|cond="in_array('passkey', explode(',', $user_config->issue_type))" disabled="disabled"|cond="!in_array('passkey', $googleotp_config->allow_issue_type)" />
+					패스키 (Passkey) <!--@if(!in_array('passkey', $googleotp_config->allow_issue_type))-->(비활성화됨)<!--@endif-->
+				</label>
+			</div>
+		</div>
+		<div class="x_control-group">
+			<label class="x_control-label" for="default_issue_type">기본 인증 수단</label>
+			<div class="x_controls">
+				<select name="default_issue_type" id="default_issue_type">
+					<option value="otp" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'otp'">Google OTP</option>
+					<option value="email" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'email'">이메일</option>
+					<option value="sms" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'sms'">문자 (SMS)</option>
+					<option value="passkey" selected="selected"|cond="($user_config->default_issue_type ?: explode(',', $user_config->issue_type)[0]) == 'passkey'">패스키 (Passkey)</option>
 				</select>
+				<p class="x_help-block">로그인 시 기본으로 사용할 인증 방식을 선택해주세요.</p>
 			</div>
 		</div>
 


### PR DESCRIPTION
- DB schema: increased issue_type size, added default_issue_type column
- Model: added helper methods for multi-method support (getIssueTypes, getDefaultIssueType, hasIssueType, getAlternativeIssueTypes)
- Controller: updated procGoogleotpUserConfig to accept multiple issue types
- Controller: added procGoogleotpSwitchAuthMethod for method switching during login
- Controller: updated procGoogleotpInputotp to use active method from session
- View: updated dispGoogleotpInputotp to pass active_issue_type and alternative_types
- Skin templates: updated userconfig.html and inputotp.html for multi-method UI
- Admin: updated membersetup.html and admin controller for multi-method support
- Module: added migration logic for new default_issue_type column