### PR TITLE
Fix null safety and otp_id column truncation causing TypeError (#5)

### DIFF
--- a/googleotp.class.php
+++ b/googleotp.class.php
@@ -307,6 +307,7 @@ class googleotp extends ModuleObject
 		if (!$oDB->isColumnExists('googleotp_authlog', 'issue_type')) return true;
 		if (!$oDB->isColumnExists('googleotp_memberconfig', 'default_issue_type')) return true;
 		if ($oDB->getColumnInfo('googleotp_memberconfig', 'issue_type')->size < 50) return true;
+		if ($oDB->isColumnExists('googleotp_memberconfig', 'otp_id') && $oDB->getColumnInfo('googleotp_memberconfig', 'otp_id')->size < 64) return true;
 
 		return false;
 	}
@@ -338,6 +339,10 @@ class googleotp extends ModuleObject
 		if ($oDB->getColumnInfo('googleotp_memberconfig', 'issue_type')->size < 50)
 		{
 			$oDB->modifyColumn('googleotp_memberconfig', 'issue_type', 'varchar', 50, null, true);
+		}
+		if ($oDB->isColumnExists('googleotp_memberconfig', 'otp_id') && $oDB->getColumnInfo('googleotp_memberconfig', 'otp_id')->size < 64)
+		{
+			$oDB->modifyColumn('googleotp_memberconfig', 'otp_id', 'varchar', 64, null, true);
 		}
 
 		return $this->createObject(0, 'success_updated');

--- a/googleotp.controller.php
+++ b/googleotp.controller.php
@@ -330,7 +330,7 @@ class googleotpController extends googleotp
 			}
 		}
 
-		if($userconfig->use === "Y") {
+		if($userconfig && $userconfig->use === "Y") {
 			$allowedact = array("dispGoogleotpInputotp","procGoogleotpInputotp","procMemberLogin","dispMemberLogout","procGoogleotpResendauthmessage","procGoogleotpSwitchAuthMethod","getMember_divideList","procGoogleotpPasskeyLoginChallenge","procGoogleotpPasskeyAuthenticate");
 			if(!in_array($obj->act, $allowedact) && !$_SESSION['googleotp_passed'])
 			{
@@ -341,7 +341,7 @@ class googleotpController extends googleotp
 			}
 		} elseif($config->force_use_otp === "Y") {
 			$allowedact = array("dispGoogleotpUserConfig","procGoogleotpUserConfig","procMemberLogin","dispMemberLogout","procGoogleotpResendauthmessage","getMember_divideList");
-			if(!in_array($obj->act, $allowedact) && (!$oGoogleOTPModel->checkUserConfig($member_srl) || $userconfig->use !== "Y"))
+			if(!in_array($obj->act, $allowedact) && (!$oGoogleOTPModel->checkUserConfig($member_srl) || !$userconfig || $userconfig->use !== "Y"))
 			{
 				$_SESSION['beforeaddress'] = getNotEncodedUrl();
 				header("Location: " . getNotEncodedUrl('act','dispGoogleotpUserConfig'));

--- a/googleotp.model.php
+++ b/googleotp.model.php
@@ -120,6 +120,7 @@ class googleotpModel extends googleotp
 	 */
 	function generateQRCode($domain, $user_id, $key)
 	{
+		if(empty($key)) return '';
 		$ga = new SimpleAuthenticator();
 		return $ga->getQRCodeGoogleUrl($key, $user_id, $domain);
 	}

--- a/googleotp.view.php
+++ b/googleotp.view.php
@@ -62,6 +62,18 @@ class googleotpView extends googleotp
 
 		$config = $this->getConfig();
 		$userconfig = $oGoogleOTPModel->getUserConfig($member_srl);
+
+		if(!$userconfig || empty($userconfig->otp_id))
+		{
+			$oGoogleOTPModel->generateNewOTP($member_srl);
+			$userconfig = $oGoogleOTPModel->getUserConfig($member_srl);
+		}
+
+		if(!$userconfig || empty($userconfig->otp_id))
+		{
+			return $this->createObject(-1, "OTP 설정을 불러올 수 없습니다.");
+		}
+
 		$userconfig->qrcode = $oGoogleOTPModel->generateQRCode($domain['host'], $logged_info->user_id, $userconfig->otp_id);
 
 		Context::set("member_srl", $member_srl);

--- a/schemas/googleotp_memberconfig.xml
+++ b/schemas/googleotp_memberconfig.xml
@@ -1,7 +1,7 @@
 <table name="googleotp_memberconfig">
     <column name="idx" type="number" notnull="notnull" primary_key="primary_key" auto_increment="auto_increment" />
     <column name="srl" type="number" notnull="notnull" />
-    <column name="otp_id" type="varchar" size="16" notnull="notnull" index="idx_otp_id" />
+    <column name="otp_id" type="varchar" size="64" notnull="notnull" index="idx_otp_id" />
     <column name="use" type="varchar" size="5" notnull="notnull" index="idx_use" />
     <column name="issue_type" type="varchar" size="50" notnull="notnull" default="none" />
     <column name="default_issue_type" type="varchar" size="10" notnull="notnull" default="none" />


### PR DESCRIPTION
- Fix otp_id column size from varchar(16) to varchar(64) to accommodate 32-char secrets
- Add migration in checkUpdate/moduleUpdate to resize existing otp_id columns
- Add null checks for $userconfig in view and controller to prevent property access on null
- Add empty check in generateQRCode() for null key parameter